### PR TITLE
feat: set MFA token to last for 9 hours

### DIFF
--- a/dotfiles/.zshrc.d/aws.plugin.zsh
+++ b/dotfiles/.zshrc.d/aws.plugin.zsh
@@ -1,6 +1,10 @@
 # use the login keychain for aws-vault so we don't need a separate password
 export AWS_VAULT_KEYCHAIN_NAME=login
 
+# set MFA token to last for 9 hours
+export AWS_SESSION_TOKEN_TTL=9h
+export AWS_CHAINED_SESSION_TOKEN_TTL=9h
+
 alias ave='aws-vault exec'
 
 # print AWS env vars as export statements
@@ -12,14 +16,14 @@ ae() {
    if [[ "$AWS_SESSION_TOKEN" ]]; then
       # clear existing session and avoid nested sessions
       # by unsetting AWS_* vars (using zsh syntax)
-      unset $(print -rC1 - $parameters[(I)AWS*] | egrep -v 'AWS_PAGER|AWS_VAULT')
+      unset $(print -rC1 - $parameters[(I)AWS*] | egrep -v 'AWS_PAGER|AWS_VAULT|TOKEN_TTL')
    fi
 
    if [[ "$1" != "--unset" ]]; then
       # eval AWS env vars in current shell
       # ignore AWS_PAGER because it has spaces
       # ignore AWS_VAULT so we can switch to other roles in the same shell
-      eval $(aws_vault_export "$1" | egrep -v 'AWS_PAGER|AWS_VAULT')
+      eval $(aws_vault_export "$1" | egrep -v 'AWS_PAGER|AWS_VAULT|TOKEN_TTL')
    fi
 }
 

--- a/install/Brewfile
+++ b/install/Brewfile
@@ -1,7 +1,7 @@
 # setup tools
 brew "stow"
 brew "duti"
-brew "getantibody/tap/antibody"
+brew "antibody"
 
 # cli tools
 brew "fzf"


### PR DESCRIPTION
the [aws-vault defaults](https://github.com/99designs/aws-vault/pull/464) are:
* GetSessionToken unchained (ie: `ae default`) will create a session for 1 hour
* GetSessionToken chained (ie: `ae <role>`) will create a session for 8 hours

this PR bumps both to 9 hours, so regardless of how you auth the MFA session token will last 9 hours.

9 hours was chosen to be just a little longer than the work day.